### PR TITLE
using defusedxml

### DIFF
--- a/emu/processes/wps_poly_centroid.py
+++ b/emu/processes/wps_poly_centroid.py
@@ -37,7 +37,7 @@ class PolyCentroid(Process):
 
     @staticmethod
     def _handler(request, response):
-        from xml.etree import ElementTree
+        from defusedxml import ElementTree
         fn = request.inputs['polygon'][0].file
 
         ns = {'gml': 'http://www.opengis.net/gml'}

--- a/environment.yml
+++ b/environment.yml
@@ -10,4 +10,6 @@ dependencies:
 - psutil
 - birdhouse-eggshell=0.3
 - libiconv
+- defusedxml
+# tests
 - pytest-flake8


### PR DESCRIPTION
## Overview

This PR updates PR #45 with recommend usage of [defusedxml](https://pypi.org/project/defusedxml/) library to parse external XML files.

Changes:

* Added `defusedxml` to conda env.
* Updated `PolyCentroid` process to use `defusedxml` to parse xml files.

## Related Issue / Discussion

PR #45.


