### PR TITLE
Fix workdir

### DIFF
--- a/emu/processes/wps_chomsky.py
+++ b/emu/processes/wps_chomsky.py
@@ -1,3 +1,4 @@
+import os
 from pywps import Process, LiteralInput, ComplexOutput, Format
 
 import logging
@@ -139,8 +140,7 @@ class Chomsky(Process):
             status_supported=True,
             store_supported=True)
 
-    @staticmethod
-    def _handler(request, response):
+    def _handler(self, request, response):
         import textwrap
         import random
         from itertools import chain, islice
@@ -154,7 +154,7 @@ class Chomsky(Process):
             output = chain(*islice(zip(*parts), 0, times))
             return textwrap.fill(' '.join(output), line_length)
 
-        with open('out.txt', 'w') as fout:
+        with open(os.path.join(self.workdir, 'out.txt'), 'w') as fout:
             fout.write(chomsky(request.inputs['times'][0].data))
             response.outputs['output'].file = fout.name
         return response

--- a/emu/processes/wps_multiple_outputs.py
+++ b/emu/processes/wps_multiple_outputs.py
@@ -43,8 +43,7 @@ class MultipleOutputs(Process):
             status_supported=True
         )
 
-    @staticmethod
-    def _handler(request, response):
+    def _handler(self, request, response):
         LOGGER.info("starting ...")
         if 'count' in request.inputs:
             max_outputs = request.inputs['count'][0].data
@@ -57,7 +56,7 @@ class MultipleOutputs(Process):
         for i in range(max_outputs):
             progress = int(i * 100.0 / max_outputs)
             response.update_status('working on document {}'.format(i), progress)
-            with open("output_{}.txt".format(i), 'w') as fp:
+            with open(os.path.join(self.workdir, "output_{}.txt".format(i)), 'w') as fp:
                 fp.write("my output file number %s" % i)
             response.outputs['output'].file = fp.name
             ref_url = response.outputs['output'].get_url()

--- a/emu/processes/wps_wordcounter.py
+++ b/emu/processes/wps_wordcounter.py
@@ -1,3 +1,4 @@
+import os
 import re
 from collections import Counter
 
@@ -43,8 +44,7 @@ class WordCounter(Process):
             store_supported=True,
             status_supported=True)
 
-    @staticmethod
-    def _handler(request, response):
+    def _handler(self, request, response):
         wordre = re.compile(r'\w+')
 
         def words(f):
@@ -55,7 +55,7 @@ class WordCounter(Process):
         counts = Counter(words(request.inputs['text'][0].stream))
         sorted_counts = sorted([(v, k) for (k, v) in counts.items()],
                                reverse=True)
-        with open('out.txt', 'w') as fout:
+        with open(os.path.join(self.workdir, 'out.txt'), 'w') as fout:
             fout.write(str(sorted_counts))
             response.outputs['output'].file = fout.name
         return response

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- pywps=4.1.0
+- pywps=4.1.2
 - jinja2
 - click
 - psutil


### PR DESCRIPTION
## Overview

This PR fixes the temp folder in processes.

Changes:

* Using `self.workdir` as temp folder.
* Update pywps 4.1.2


