### PR TITLE
skip eggshell

### DIFF
--- a/emu/processes/wps_output_formats.py
+++ b/emu/processes/wps_output_formats.py
@@ -6,11 +6,12 @@ Author: David Huard
 import os
 from pywps import Process, ComplexOutput
 from pywps import FORMATS
-from eggshell.config import Paths
-import emu
+
 import logging
 LOGGER = logging.getLogger("PYWPS")
-paths = Paths(emu)
+
+# TODO: can be replaced by eggshell function.
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
 
 
 class OutputFormats(Process):
@@ -43,8 +44,8 @@ class OutputFormats(Process):
     def _handler(request, response):
         response.update_status('PyWPS Process started.', 0)
 
-        response.outputs['netcdf'].file = os.path.join(paths.data, 'dummy.nc')
-        response.outputs['json'].file = os.path.join(paths.data, 'dummy.json')
+        response.outputs['netcdf'].file = os.path.join(DATA_DIR, 'dummy.nc')
+        response.outputs['json'].file = os.path.join(DATA_DIR, 'dummy.json')
 
         response.update_status('PyWPS Process completed.', 100)
         return response

--- a/environment.yml
+++ b/environment.yml
@@ -1,15 +1,13 @@
 name: emu
 channels:
-- birdhouse
 - conda-forge
 - defaults
 dependencies:
 - six
-- pywps>=4.1.26
+- pywps>=4.2.1
 - jinja2
 - click
 - psutil
-- birdhouse-eggshell=0.3
 - libiconv
 - defusedxml
 # opendap support


### PR DESCRIPTION
## Overview

This PR skips the eggshell for now. `eggshell` is quite fragile ... we can let it grow with flyingpigeon and blackswan. 

Emu might be used as wps test service:
https://github.com/bird-house/bird-house.github.io/issues/28

Changes:

* Skipped eggshell (process `OutputFormats`)
* Updated pywps
* only use packages from conda-forge (skipped birdhouse)

## Related Issue / Discussion

## Additional Information


