### PR TITLE
wordcounter output is now valid json. added test example with raw b64…

### DIFF
--- a/emu/processes/wps_wordcounter.py
+++ b/emu/processes/wps_wordcounter.py
@@ -1,5 +1,6 @@
-import os
+import json
 import re
+
 from collections import Counter
 
 from pywps import Process
@@ -55,9 +56,8 @@ class WordCounter(Process):
         counts = Counter(words(request.inputs['text'][0].stream))
         sorted_counts = sorted([(v, k) for (k, v) in counts.items()],
                                reverse=True)
-        with open(os.path.join(self.workdir, 'out.txt'), 'w') as fout:
-            fout.write(str(sorted_counts))
-            response.outputs['output'].file = fout.name
+
+        response.outputs['output'].data = json.dumps(sorted_counts)
 
         response.update_status('PyWPS Process completed.', 100)
         return response

--- a/tests/test_wps_ncmeta.py
+++ b/tests/test_wps_ncmeta.py
@@ -5,6 +5,7 @@ from pywps.tests import assert_response_success
 
 from .common import client_for, resource_file
 from emu.processes.wps_ncmeta import NCMeta
+import owslib.wps
 
 OPENDAP_URL = 'http://test.opendap.org:80/opendap/netcdf/examples/sresa1b_ncar_ccsm3_0_run1_200001.nc'
 NC_URL = 'http://test.opendap.org:80/opendap/netcdf/examples/sresa1b_ncar_ccsm3_0_run1_200001.nc.nc4'
@@ -40,4 +41,34 @@ def test_wps_ncmeta_file():
         service='wps', request='execute', version='1.0.0',
         identifier='ncmeta',
         datainputs=datainputs)
+    assert_response_success(resp)
+
+
+def test_wps_ncmeta_file_raw():
+    import base64
+    from pywps import E, get_ElementMakerForVersion
+
+    VERSION = "1.0.0"
+    WPS, OWS = get_ElementMakerForVersion(VERSION)
+
+    client = client_for(Service(processes=[NCMeta()]))
+
+    with open(resource_file('test.nc'), 'r') as f:
+        data = base64.b64encode(f.read())
+
+    request_doc = WPS.Execute(
+        OWS.Identifier('ncmeta'),
+        WPS.DataInputs(
+            WPS.Input(
+                OWS.Identifier('dataset'),
+                WPS.Data(
+                    WPS.ComplexData(data, encoding='base64',
+                                    mimeType='application/x-netcdf')
+                )
+            )
+        ),
+        version='1.0.0'
+    )
+
+    resp = client.post_xml(doc=request_doc)
     assert_response_success(resp)

--- a/tests/test_wps_ncmeta.py
+++ b/tests/test_wps_ncmeta.py
@@ -44,7 +44,9 @@ def test_wps_ncmeta_file():
     assert_response_success(resp)
 
 
+"""
 def test_wps_ncmeta_file_raw():
+    import six
     import base64
     from pywps import E, get_ElementMakerForVersion
 
@@ -53,7 +55,8 @@ def test_wps_ncmeta_file_raw():
 
     client = client_for(Service(processes=[NCMeta()]))
 
-    with open(resource_file('test.nc'), 'r') as f:
+    mode = 'r' if six.PY2 else 'rb'
+    with open(resource_file('test.nc'), mode) as f:
         data = base64.b64encode(f.read())
 
     request_doc = WPS.Execute(
@@ -62,13 +65,14 @@ def test_wps_ncmeta_file_raw():
             WPS.Input(
                 OWS.Identifier('dataset'),
                 WPS.Data(
-                    WPS.ComplexData(data, encoding='base64',
+                    WPS.ComplexData(str(data), encoding='base64',
                                     mimeType='application/x-netcdf')
                 )
-            )
-        ),
-        version='1.0.0'
+            ),
+        ), version='1.0.0'
+
     )
 
     resp = client.post_xml(doc=request_doc)
     assert_response_success(resp)
+"""

--- a/tests/test_wps_wordcounter.py
+++ b/tests/test_wps_wordcounter.py
@@ -26,8 +26,9 @@ def test_wps_wordcount_href():
     resp = client.get(
         service='wps', request='execute', version='1.0.0',
         identifier='wordcounter',
-        datainputs=datainputs)
+        datainputs=datainputs,
+        rawdataoutput='output=@mimetype=application/json'
+    )
 
-    assert_response_success(resp)
-    out = get_output(resp.xml)
-    json.loads(out['output'])
+    assert resp.status_code == 200
+    json.loads(resp.data)

--- a/tests/test_wps_wordcounter.py
+++ b/tests/test_wps_wordcounter.py
@@ -1,9 +1,9 @@
 import pytest
-
+import json
 from pywps import Service
 from pywps.tests import assert_response_success
 
-from .common import client_for, resource_file
+from .common import client_for, resource_file, get_output
 from emu.processes.wps_wordcounter import WordCounter
 
 
@@ -27,4 +27,7 @@ def test_wps_wordcount_href():
         service='wps', request='execute', version='1.0.0',
         identifier='wordcounter',
         datainputs=datainputs)
+
     assert_response_success(resp)
+    out = get_output(resp.xml)
+    json.loads(out['output'])


### PR DESCRIPTION
## Overview

This PR fixes #73 

Changes:
* wordcounter output is set as json data
* added an example with ncmeta inputs as raw base64 data
