### PR TITLE
added simple dry run example

### DIFF
--- a/emu/processes/__init__.py
+++ b/emu/processes/__init__.py
@@ -15,6 +15,7 @@ from .wps_output_formats import OutputFormats
 from .wps_poly_centroid import PolyCentroid
 from .wps_ncmeta import NCMeta
 from .wps_nonpyid import NonPyID
+from .wps_dry_run import SimpleDryRun
 
 processes = [
     UltimateQuestion(),
@@ -34,4 +35,5 @@ processes = [
     PolyCentroid(),
     NCMeta(),
     NonPyID(),
+    SimpleDryRun(),
 ]

--- a/emu/processes/wps_dry_run.py
+++ b/emu/processes/wps_dry_run.py
@@ -16,6 +16,7 @@ class SimpleDryRun(Process):
             LiteralInput('num_files', 'Number of Files (Limit 10)',
                          abstract='How many files do you want to download? The limit is 10',
                          data_type='integer',
+                         allowed_values=[AllowedValue(minval=1, maxval=100)],
                          default=1,), ]
         outputs = [
             LiteralOutput('output', 'Output response',

--- a/emu/processes/wps_dry_run.py
+++ b/emu/processes/wps_dry_run.py
@@ -1,0 +1,58 @@
+from pywps import Process, LiteralInput, LiteralOutput
+from pywps.inout.literaltypes import AllowedValue
+from pywps.app.Common import Metadata
+
+import logging
+LOGGER = logging.getLogger("PYWPS")
+
+
+class SimpleDryRun(Process):
+    """An example of implementing a dry-run to protect your process from unwanted resource usage."""
+    def __init__(self):
+        inputs = [
+            LiteralInput('dry_run', 'Dry run mode. Default false',
+                         data_type='boolean',
+                         default=False,),
+            LiteralInput('num_files', 'Number of Files (Limit 10)',
+                         abstract='How many files do you want to download? The limit is 10',
+                         data_type='integer',
+                         default=1,), ]
+        outputs = [
+            LiteralOutput('output', 'Output response',
+                          data_type='string')]
+
+        super(SimpleDryRun, self).__init__(
+            self._handler,
+            identifier='simple_dry_run',
+            title='Simple Dry Run',
+            abstract='A dummy download as simple dry-run example.',
+            metadata=[
+                Metadata('User Guide', 'https://emu.readthedocs.io/en/latest/processes.html'),  # noqa
+            ],
+            version='1.0',
+            inputs=inputs,
+            outputs=outputs,
+            store_supported=True,
+            status_supported=True
+        )
+
+    @staticmethod
+    def _handler(request, response):
+        # TODO: we need a more informational user exception in pywps.
+        response.update_status('PyWPS Process started.', 0)
+
+        num_files = request.inputs['num_files'][0].data
+
+        if num_files > 10:
+            msg = "Too many files too download: {} > 10".format(num_files)
+            LOGGER.error(msg)
+            raise Exception(msg)
+
+        if request.inputs['dry_run'][0].data is True:
+            msg = "We would download {} files.".format(num_files)
+            LOGGER.warning(msg)
+            raise Exception(msg)
+
+        response.outputs['output'].data = 'File downloads done: {}'.format(num_files)
+        response.update_status('PyWPS Process completed.', 100)
+        return response

--- a/emu/processes/wps_dry_run.py
+++ b/emu/processes/wps_dry_run.py
@@ -1,6 +1,7 @@
 from pywps import Process, LiteralInput, LiteralOutput
 from pywps.inout.literaltypes import AllowedValue
 from pywps.app.Common import Metadata
+from pywps.validator.mode import MODE
 
 import logging
 LOGGER = logging.getLogger("PYWPS")
@@ -17,7 +18,8 @@ class SimpleDryRun(Process):
                          abstract='How many files do you want to download? The limit is 10',
                          data_type='integer',
                          allowed_values=[AllowedValue(minval=1, maxval=100)],
-                         default=1,), ]
+                         default=1,
+                         mode=MODE.NONE), ]
         outputs = [
             LiteralOutput('output', 'Output response',
                           data_type='string')]

--- a/tests/test_wps_caps.py
+++ b/tests/test_wps_caps.py
@@ -27,6 +27,7 @@ def test_wps_caps():
         'output_formats',
         'poly_centroid',
         'show_error',
+        'simple_dry_run',
         'sleep',
         'ultimate_question',
         'wordcounter',


### PR DESCRIPTION
## Overview

This PR adds an example with a *dry run* option to prevent unwanted resource usage.

The process raises an exception when:
* the calculated resource limits are exceeded (too many files, ...),
* the `--dry_run` mode is set and information about used calculated resources is returned.



## Related Issue / Discussion

## Additional Information

We need the support of *user exceptions* in pywps:
https://github.com/geopython/pywps/issues/406

COWS WPS has a dry-run option:
http://cows.ceda.ac.uk/cows_wps/features.html#dry-run-execution-for-resource-estimation

