### PR TITLE
Add thredds to docker-compose as DAP server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,23 @@
 version: '3'
 services:
   emu:
+    # http://localhost:5000/wps
     build: .
     image: birdhouse/emu:dev
     ports:
       - "5000:5000"
     volumes:
       - outputpath:/tmp
+
+  thredds:
+    # Thredds is used as DAP server for Emu outputs
+    # http://localhost:8080/thredds/catalog.html
+    image: unidata/thredds-docker:4.6.14
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./threddsCatalog.xml:/usr/local/tomcat/content/thredds/catalog.xml:ro
+      - outputpath:/wps_outputs:ro
 
 volumes:
     outputpath: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,16 @@ services:
     image: birdhouse/emu:dev
     ports:
       - "5000:5000"
+    volumes:
+      - outputpath:/tmp
 
+volumes:
+    outputpath: {}
 
 # docker-compose build
 # docker-compose up
-# docker-compose down
+# docker-compose down -v
+#    -v, --volumes       Remove named volumes declared in the `volumes` section
+#                        of the Compose file and anonymous volumes
+#                        attached to containers.
 # docker-compose rm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   emu:
     build: .
-    image: birdhouse/emu
+    image: birdhouse/emu:dev
     ports:
       - "5000:5000"
 

--- a/threddsCatalog.xml
+++ b/threddsCatalog.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog name="Emu Thredds Catalog"
+         xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+         xmlns:xlink="http://www.w3.org/1999/xlink" >
+
+    <service name="all" serviceType="Compound" base="" >
+        <!-- HTTPServer works for all file types. -->
+        <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/" />
+
+        <!-- Services below known to work with .nc and .ncml files only. -->
+        <service name="odap" serviceType="OpenDAP" base="/thredds/dodsC/" />
+        <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
+        <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>
+        <service name="iso" serviceType="ISO" base="/thredds/iso/"/>
+    </service>
+
+    <datasetScan name="Emu" ID="emu" path="emu" location="/wps_outputs">
+
+      <metadata inherited="true">
+        <serviceName>all</serviceName>
+      </metadata>
+
+      <filter>
+        <!-- basic file types -->
+        <include wildcard="*.nc" />
+        <include wildcard="*.ncml" />
+        <include wildcard="*.txt" />
+        <include wildcard="*.md" />
+        <include wildcard="*.rst" />
+
+        <!-- file types from emu.multiple_outputs -->
+        <include wildcard="*.metalink" />
+        <include wildcard="*.meta4" />
+
+        <!-- file types from emu.output_formats -->
+        <include wildcard="*.json" />
+      </filter>
+
+    </datasetScan>
+
+</catalog>


### PR DESCRIPTION
## Overview

This PR fixes #98 

Changes:

* Added Thredds docker image to run along side Emu docker image
* The outputpath of Emu is shown as Thredds catalog

## Related Issue / Discussion

## Additional Information

Test notebook calling emu.multiple_outputs() and emu.multiple_outputs(): https://gist.github.com/tlvu/ac20f7f864585156ba6635e3d4792b2f

Thredds corresponding screenshot:

![2020-02-12-154705_1143x452_scrot](https://user-images.githubusercontent.com/11966697/74376463-27784e00-4db0-11ea-94fb-8eb342430726.png)

![2020-02-12-154717_1145x317_scrot](https://user-images.githubusercontent.com/11966697/74376478-2fd08900-4db0-11ea-812e-89ed54b47769.png)

![2020-02-12-154729_1144x586_scrot](https://user-images.githubusercontent.com/11966697/74376490-352dd380-4db0-11ea-8cf2-ecc11a89186d.png)

![2020-02-12-154742_1138x721_scrot](https://user-images.githubusercontent.com/11966697/74376492-37902d80-4db0-11ea-907e-66c04f8dbbf8.png)

![2020-02-12-154805_1143x314_scrot](https://user-images.githubusercontent.com/11966697/74376497-39f28780-4db0-11ea-824f-50ba6d6412fe.png)






