### PR TITLE
pin python 3.6

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 - defaults
 dependencies:
 - pip
+- python=3.6
 - pywps=4.2
 - jinja2
 - click


### PR DESCRIPTION
## Overview

This PR pins python=3.6 in the conda env.

## Related Issue / Discussion

## Additional Information

