### PR TITLE
Refresh cookiecutter for more robust doc build

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
     "template": "https://github.com/bird-house/cookiecutter-birdhouse.git",
-    "commit": "73eee18ca4a16763335d18ed9512cc617fbcc777",
+    "commit": "f1c509815eb76215b25fc4c88917614d59530478",
     "skip": [
         "emu/processes/wps_say_hello.py",
         "tests/test_wps_hello.py",

--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
     "template": "https://github.com/bird-house/cookiecutter-birdhouse.git",
-    "commit": "f1c509815eb76215b25fc4c88917614d59530478",
+    "commit": "7ec7b8b69bbb900d6a300854af0e2a7357b83cdf",
     "skip": [
         "emu/processes/wps_say_hello.py",
         "tests/test_wps_hello.py",

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,9 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
+  # fail_on_warning might generate hard to fix error, in this case it can be
+  # disabled but this also means those errors will fail silently, choose wisely.
+  fail_on_warning: true
 
 # Build documentation with MkDocs
 #mkdocs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 #  - osx
 sudo: false
 before_install:
@@ -37,4 +38,6 @@ script:
   # No notebooks in emu yet.
   #- make test-notebooks
   - flake8
-  - make docs
+  - make docs  # default html
+  - make SPHINXOPTS='-b epub' docs  # to match RtD
+  - make SPHINXOPTS='-b latex' docs  # to match RtD

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,11 @@ COPY . /opt/wps
 
 WORKDIR /opt/wps
 
-# Create conda environment
-RUN conda env create -n wps -f environment.yml
+# Create conda environment with PyWPS
+RUN ["conda", "env", "create", "-n", "wps", "-f", "environment.yml"]
 
 # Install WPS
-RUN ["/bin/bash", "-c", "source activate wps && python setup.py develop"]
+RUN ["/bin/bash", "-c", "source activate wps && pip install -e ."]
 
 # Start WPS service on port 5000 on 0.0.0.0
 EXPOSE 5000

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ install:
 develop:
 	@echo "Installing development requirements for tests and docs ..."
 	@-bash -c 'pip install -e ".[dev]"'
+	@-bash -c 'pip install git+https://github.com/Ouranosinc/pywps@2a55b6e95f51c648dc94bf3c89db7370b56c1c9c#egg=pywps --upgrade'
 
 .PHONY: start
 start:

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ refresh-notebooks:
 .PHONY: docs
 docs:
 	@echo "Generating docs with Sphinx ..."
-	@-bash -c '$(MAKE) -C $@ clean html'
+	@bash -c '$(MAKE) -C $@ clean html'
 	@echo "Open your browser to: file:/$(APP_ROOT)/docs/build/html/index.html"
 	## do not execute xdg-open automatically since it hangs travis and job does not complete
 	@echo "xdg-open $(APP_ROOT)/docs/build/html/index.html"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,4 +17,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" -W $(SPHINXOPTS) $(O)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,20 +35,35 @@ sys.path.insert(0, os.path.abspath("../../"))
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.viewcode',
-              'sphinx.ext.napoleon',
-              'sphinx.ext.todo',
-              'pywps.ext_autodoc',
-              ]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.todo",
+    "pywps.ext_autodoc",
+    "sphinx.ext.autosectionlabel",
+    "sphinx.ext.imgconverter",
+    "nbsphinx",
+    "IPython.sphinxext.ipython_console_highlighting",
+]
 
 # To avoid having to install these and burst memory limit on ReadTheDocs.
+# List of all tested working mock imports from all birds so new birds can
+# inherit without having to test which work which do not.
 autodoc_mock_imports = ["numpy", "xarray", "fiona", "rasterio", "shapely",
                         "osgeo", "geopandas", "pandas", "statsmodels",
                         "affine", "rasterstats", "spotpy", "matplotlib",
                         "scipy", "unidecode", "gdal", "sentry_sdk", "dask",
                         "numba", "parse", "siphon", "sklearn", "cftime",
-                        "netCDF4"]
+                        "netCDF4", "bottleneck", "ocgis", "geotiff", "geos",
+                        "hdf4", "hdf5", "zlib", "pyproj", "proj", "cartopy",
+                        "scikit-learn", "cairo"]
+
+# Monkeypatch constant because the following are mock imports.
+# Only works if numpy is actually installed and at the same time being mocked.
+#import numpy
+#numpy.pi = 3.1416
 
 # We are using mock imports in readthedocs, so probably safer to not run the notebooks
 nbsphinx_execute = 'never'
@@ -75,7 +90,7 @@ author = "Carsten Ehbrecht"
 # the built documents.
 #
 # The short X.Y version.
-version = ""
+version = "0.11.1"
 # The full version, including alpha/beta/rc tags.
 release = "0.11.1"
 
@@ -96,6 +111,12 @@ pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
+
+# Suppress "WARNING: unknown mimetype for ..." when building EPUB.
+suppress_warnings = ['epub.unknown_project_files']
+
+# Avoid "configuration.rst:4:duplicate label configuration, other instance in configuration.rst"
+autosectionlabel_prefix_document = True
 
 
 # -- Options for HTML output -------------------------------------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -14,10 +14,6 @@ Install from Conda
    :target: http://anaconda.org/birdhouse/emu
    :alt: Ananconda Install
 
-.. image:: http://anaconda.org/birdhouse/emu/badges/build.svg
-   :target: http://anaconda.org/birdhouse/emu
-   :alt: Anaconda Build
-
 .. image:: http://anaconda.org/birdhouse/emu/badges/version.svg
    :target: http://anaconda.org/birdhouse/emu
    :alt: Anaconda Version

--- a/emu/processes/wps_bbox.py
+++ b/emu/processes/wps_bbox.py
@@ -1,4 +1,5 @@
 from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 
 __author__ = 'Jachym'
 
@@ -30,7 +31,9 @@ class Box(Process):
             abstract='Give bounding box, return the same',
             metadata=[
                 Metadata('Birdhouse', 'http://bird-house.github.io/'),
-                Metadata('User Guide', 'http://emu.readthedocs.io/en/latest/')],
+                MetadataUrl('User Guide',
+                            'http://emu.readthedocs.io/en/latest/',
+                            anonymous=True)],
             inputs=inputs,
             outputs=outputs,
             store_supported=True,

--- a/emu/processes/wps_binaryoperator.py
+++ b/emu/processes/wps_binaryoperator.py
@@ -1,5 +1,6 @@
 from pywps import Process, LiteralInput, LiteralOutput
 from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 
 import logging
 logger = logging.getLogger("PYWPS")
@@ -30,7 +31,9 @@ class BinaryOperator(Process):
                      'This example process is taken from Climate4Impact.',
             metadata=[
                 Metadata('Birdhouse', 'http://bird-house.github.io/'),
-                Metadata('User Guide', 'http://emu.readthedocs.io/en/latest/'),
+                MetadataUrl('User Guide',
+                            'http://emu.readthedocs.io/en/latest/',
+                            anonymous=True),
                 Metadata('Climate4Impact', 'https://dev.climate4impact.eu')],
             version='1.0',
             inputs=inputs,

--- a/emu/processes/wps_chomsky.py
+++ b/emu/processes/wps_chomsky.py
@@ -102,8 +102,7 @@ the strong generative capacity of the theory."""
 
 class Chomsky(Process):
     """
-    Notes
-    -----
+    Notes:
 
     Generates a random chomsky text:
     http://code.activestate.com/recipes/440546-chomsky-random-text-generator/

--- a/emu/processes/wps_dry_run.py
+++ b/emu/processes/wps_dry_run.py
@@ -1,6 +1,6 @@
 from pywps import Process, LiteralInput, LiteralOutput
 from pywps.inout.literaltypes import AllowedValue
-from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 from pywps.validator.mode import MODE
 
 from emu.exceptions import DryRunWarning, StorageLimitExceeded
@@ -32,7 +32,9 @@ class SimpleDryRun(Process):
             title='Simple Dry Run',
             abstract='A dummy download as simple dry-run example.',
             metadata=[
-                Metadata('User Guide', 'https://emu.readthedocs.io/en/latest/processes.html'),  # noqa
+                MetadataUrl('User Guide',
+                            'https://emu.readthedocs.io/en/latest/processes.html',
+                            anonymous=True),
             ],
             version='1.0',
             inputs=inputs,

--- a/emu/processes/wps_error.py
+++ b/emu/processes/wps_error.py
@@ -1,5 +1,6 @@
 from pywps import Process, LiteralInput
 from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 from pywps.app.exceptions import ProcessError
 
 import logging
@@ -37,7 +38,10 @@ class ShowError(Process):
             metadata=[
                 Metadata('PyWPS', 'https://pywps.org/'),
                 Metadata('Birdhouse', 'http://bird-house.github.io/'),
-                Metadata('User Guide', 'http://emu.readthedocs.io/en/latest/')],
+                MetadataUrl('User Guide',
+                            'http://emu.readthedocs.io/en/latest/',
+                            anonymous=True),
+            ],
             version='1.0',
             inputs=inputs,
             # outputs=outputs,

--- a/emu/processes/wps_esgf.py
+++ b/emu/processes/wps_esgf.py
@@ -3,6 +3,7 @@ from pywps import LiteralInput, LiteralOutput
 from pywps import ComplexInput
 from pywps import Format
 from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 
 import logging
 LOGGER = logging.getLogger("PYWPS")
@@ -38,7 +39,9 @@ class ESGFDemo(Process):
             title='ESGF Demo',
             abstract='Shows how to use WPS metadata for processes using ESGF data.',
             metadata=[
-                Metadata('User Guide', 'https://emu.readthedocs.io/en/latest/processes.html'),  # noqa
+                MetadataUrl('User Guide',
+                            'https://emu.readthedocs.io/en/latest/processes.html',
+                            anonymous=True),
                 Metadata('ESGF Constraints',
                          role='https://www.earthsystemcog.org/spec/esgf_search/4.12.0/def/constraints',  # noqa
                          href='http://esgf-data.dkrz.de/esg-search/search?project=CMIP5&time_frequency=mon&variable=tas,tasmax,tasmin&experiment=historical'),  # noqa

--- a/emu/processes/wps_inout.py
+++ b/emu/processes/wps_inout.py
@@ -9,6 +9,7 @@ from pywps import ComplexInput, ComplexOutput
 from pywps import Format, FORMATS
 from pywps.validator.mode import MODE
 from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 
 
 import logging
@@ -67,8 +68,10 @@ class InOut(Process):
             LiteralInput('int_range', 'Integer Range',
                          abstract='Choose number from range: 1-10 (step 1), 100-200 (step 10)',
                          metadata=[
-                            Metadata('PyWPS Docs', 'https://pywps.readthedocs.io/en/master/api.html#pywps.inout.literaltypes.AllowedValue'),  # noqa
-                            Metadata('AllowedValue Example', 'http://docs.opengeospatial.org/is/14-065/14-065.html#98'),  # noqa
+                             MetadataUrl('PyWPS Docs',
+                                         'https://pywps.readthedocs.io/en/master/api.html#pywps.inout.literaltypes.AllowedValue',  # noqa
+                                         anonymous=True),
+                             Metadata('AllowedValue Example', 'http://docs.opengeospatial.org/is/14-065/14-065.html#98'),  # noqa
                          ],
                          data_type='integer',
                          default='1',
@@ -80,7 +83,9 @@ class InOut(Process):
             LiteralInput('any_value', 'Any Value',
                          abstract='Enter any value.',
                          metadata=[
-                            Metadata('PyWPS Docs', 'https://pywps.readthedocs.io/en/master/api.html#pywps.inout.literaltypes.AnyValue'),  # noqa
+                             MetadataUrl('PyWPS Docs',
+                                         'https://pywps.readthedocs.io/en/master/api.html#pywps.inout.literaltypes.AnyValue',  # noqa
+                                         anonymous=True),
                          ],
                          allowed_values=AnyValue(),
                          default='any value',
@@ -88,7 +93,9 @@ class InOut(Process):
             LiteralInput('ref_value', 'Referenced Value',
                          abstract='Choose a referenced value',
                          metadata=[
-                            Metadata('PyWPS Docs', 'https://pywps.readthedocs.io/en/master/_modules/pywps/inout/literaltypes.html'),  # noqa
+                             MetadataUrl('PyWPS Docs',
+                                         'https://pywps.readthedocs.io/en/master/_modules/pywps/inout/literaltypes.html',  # noqa
+                                         anonymous=True),
                          ],
                          data_type='string',
                          allowed_values=ValuesReference(
@@ -155,8 +162,10 @@ class InOut(Process):
             # profile=['birdhouse'],
             metadata=[
                 Metadata('Birdhouse', 'http://bird-house.github.io/'),
-                Metadata('User Guide', 'http://emu.readthedocs.io/en/latest/',
-                         role='http://www.opengis.net/spec/wps/2.0/def/process/description/documentation')],
+                MetadataUrl('User Guide', 'http://emu.readthedocs.io/en/latest/',
+                            role='http://www.opengis.net/spec/wps/2.0/def/process/description/documentation',
+                            anonymous=True),
+            ],
             inputs=inputs,
             outputs=outputs,
             status_supported=True,

--- a/emu/processes/wps_inout.py
+++ b/emu/processes/wps_inout.py
@@ -68,9 +68,8 @@ class InOut(Process):
             LiteralInput('int_range', 'Integer Range',
                          abstract='Choose number from range: 1-10 (step 1), 100-200 (step 10)',
                          metadata=[
-                             MetadataUrl('PyWPS Docs',
-                                         'https://pywps.readthedocs.io/en/master/api.html#pywps.inout.literaltypes.AllowedValue',  # noqa
-                                         anonymous=True),
+                             Metadata('AllowedValue PyWPS Docs',
+                                      'https://pywps.readthedocs.io/en/master/api.html#pywps.inout.literaltypes.AllowedValue'),  # noqa
                              Metadata('AllowedValue Example', 'http://docs.opengeospatial.org/is/14-065/14-065.html#98'),  # noqa
                          ],
                          data_type='integer',
@@ -83,9 +82,8 @@ class InOut(Process):
             LiteralInput('any_value', 'Any Value',
                          abstract='Enter any value.',
                          metadata=[
-                             MetadataUrl('PyWPS Docs',
-                                         'https://pywps.readthedocs.io/en/master/api.html#pywps.inout.literaltypes.AnyValue',  # noqa
-                                         anonymous=True),
+                             Metadata('AnyValue PyWPS Docs',
+                                      'https://pywps.readthedocs.io/en/master/api.html#pywps.inout.literaltypes.AnyValue'),  # noqa
                          ],
                          allowed_values=AnyValue(),
                          default='any value',
@@ -93,9 +91,8 @@ class InOut(Process):
             LiteralInput('ref_value', 'Referenced Value',
                          abstract='Choose a referenced value',
                          metadata=[
-                             MetadataUrl('PyWPS Docs',
-                                         'https://pywps.readthedocs.io/en/master/_modules/pywps/inout/literaltypes.html',  # noqa
-                                         anonymous=True),
+                             Metadata('PyWPS Docs',
+                                      'https://pywps.readthedocs.io/en/master/_modules/pywps/inout/literaltypes.html'),  # noqa
                          ],
                          data_type='string',
                          allowed_values=ValuesReference(

--- a/emu/processes/wps_multiple_outputs.py
+++ b/emu/processes/wps_multiple_outputs.py
@@ -2,7 +2,7 @@ import os
 from pywps import Process, LiteralInput, ComplexOutput
 from pywps import FORMATS
 from pywps.inout.literaltypes import AllowedValue
-from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 from pywps.inout.outputs import MetaLink, MetaLink4, MetaFile
 import json
 
@@ -36,7 +36,9 @@ class MultipleOutputs(Process):
             abstract='Produces multiple files and returns a document'
                      ' with references to these files.',
             metadata=[
-                Metadata('User Guide', 'https://emu.readthedocs.io/en/latest/processes.html'),  # noqa
+                MetadataUrl('User Guide',
+                            'https://emu.readthedocs.io/en/latest/processes.html',
+                            anonymous=True),
             ],
             version='1.1',
             inputs=inputs,

--- a/emu/processes/wps_nap.py
+++ b/emu/processes/wps_nap.py
@@ -1,5 +1,6 @@
 from pywps import Process, LiteralInput, LiteralOutput
 from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 
 
 class Nap(Process):
@@ -23,7 +24,10 @@ class Nap(Process):
             profile='',
             metadata=[
                 Metadata('Birdhouse', 'http://bird-house.github.io/'),
-                Metadata('User Guide', 'http://emu.readthedocs.io/en/latest/')],
+                MetadataUrl('User Guide',
+                            'http://emu.readthedocs.io/en/latest/',
+                            anonymous=True),
+            ],
             inputs=inputs,
             outputs=outputs,
             store_supported=False,

--- a/emu/processes/wps_nc_to_dap.py
+++ b/emu/processes/wps_nc_to_dap.py
@@ -1,6 +1,6 @@
 from pywps import Process
 from pywps import ComplexInput, ComplexOutput, FORMATS
-from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 from pywps import configuration
 import logging
 
@@ -33,7 +33,9 @@ class NcToDap(Process):
             abstract="Return Data Access Protocol link to a netCDF or NcML file.",
             version="1",
             metadata=[
-                Metadata('User Guide', 'http://emu.readthedocs.io/en/latest/'),
+                MetadataUrl('User Guide',
+                            'http://emu.readthedocs.io/en/latest/',
+                            anonymous=True),
             ],
             inputs=inputs,
             outputs=outputs,

--- a/emu/processes/wps_ncmeta.py
+++ b/emu/processes/wps_ncmeta.py
@@ -17,8 +17,7 @@ TEST_URL = 'http://test.opendap.org:80/opendap/netcdf/examples/sresa1b_ncar_ccsm
 
 class NCMeta(Process):
     """
-    Notes
-    -----
+    Notes:
 
     Returns metadata of a NetCDF file or OpenDAP resource.
     """

--- a/emu/processes/wps_ncmeta.py
+++ b/emu/processes/wps_ncmeta.py
@@ -4,7 +4,7 @@ from pywps import Process
 from pywps import ComplexInput, ComplexOutput, FORMATS, Format
 from pywps.inout.basic import SOURCE_TYPE
 from pywps.validator.mode import MODE
-from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 
 from netCDF4 import Dataset
 
@@ -51,7 +51,9 @@ class NCMeta(Process):
             abstract="Return metadata from a netCDF dataset, either on file or an OpenDAP service.",
             version='4',
             metadata=[
-                Metadata('User Guide', 'http://emu.readthedocs.io/en/latest/'),
+                MetadataUrl('User Guide',
+                            'http://emu.readthedocs.io/en/latest/',
+                            anonymous=True),
             ],
             inputs=inputs,
             outputs=outputs,

--- a/emu/processes/wps_ncml.py
+++ b/emu/processes/wps_ncml.py
@@ -2,7 +2,7 @@ import os
 import xarray.tests.test_dataset as td
 from pywps import Process
 from pywps import ComplexOutput, FORMATS
-from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 import logging
 
 
@@ -31,7 +31,9 @@ class NcMLAgg(Process):
             abstract="Return links to an NcML file aggregating netCDF files with moving time units.",
             version="1",
             metadata=[
-                Metadata('User Guide', 'http://emu.readthedocs.io/en/latest/'),
+                MetadataUrl('User Guide',
+                            'http://emu.readthedocs.io/en/latest/',
+                            anonymous=True),
             ],
             inputs=inputs,
             outputs=outputs,

--- a/emu/processes/wps_say_hello.py
+++ b/emu/processes/wps_say_hello.py
@@ -1,5 +1,6 @@
 from pywps import Process, LiteralInput, LiteralOutput, UOM
 from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 
 import logging
 LOGGER = logging.getLogger("PYWPS")
@@ -27,7 +28,9 @@ class SayHello(Process):
                      'Returns a literal string output with Hello plus the inputed name.',
             keywords=['hello', 'demo'],
             metadata=[
-                Metadata('User Guide', 'https://emu.readthedocs.io/en/latest/processes.html'),  # noqa
+                MetadataUrl('User Guide',
+                            'https://emu.readthedocs.io/en/latest/processes.html',
+                            anonymous=True),  # noqa
                 Metadata('PyWPS Demo', 'https://pywps-demo.readthedocs.io/en/latest/'),
             ],
             version='1.5',

--- a/emu/processes/wps_sleep.py
+++ b/emu/processes/wps_sleep.py
@@ -1,5 +1,6 @@
 from pywps import Process, LiteralInput, LiteralOutput
 from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 
 
 class Sleep(Process):
@@ -22,7 +23,9 @@ class Sleep(Process):
                      'This process will sleep for a given delay or 10 seconds if not a valid value.',
             profile='',
             metadata=[
-                Metadata('User Guide', 'https://emu.readthedocs.io/en/latest/processes.html'),  # noqa
+                MetadataUrl('User Guide',
+                            'https://emu.readthedocs.io/en/latest/processes.html',
+                            anonymous=True),  # noqa
                 Metadata('PyWPS Demo', 'https://pywps-demo.readthedocs.io/en/latest/'),
             ],
             inputs=inputs,

--- a/emu/processes/wps_wordcounter.py
+++ b/emu/processes/wps_wordcounter.py
@@ -13,8 +13,7 @@ LOGGER = logging.getLogger("PYWPS")
 
 class WordCounter(Process):
     """
-    Notes
-    -----
+    Notes:
 
     Counts occurrences of all words in a document.
     """

--- a/emu/processes/wps_wordcounter.py
+++ b/emu/processes/wps_wordcounter.py
@@ -5,7 +5,7 @@ from collections import Counter
 
 from pywps import Process
 from pywps import ComplexInput, ComplexOutput, FORMATS
-from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 
 import logging
 LOGGER = logging.getLogger("PYWPS")
@@ -35,7 +35,9 @@ class WordCounter(Process):
             abstract="Counts words in a given text.",
             version='1.0',
             metadata=[
-                Metadata('User Guide', 'http://emu.readthedocs.io/en/latest/'),
+                MetadataUrl('User Guide',
+                            'http://emu.readthedocs.io/en/latest/',
+                            anonymous=True),
             ],
             inputs=inputs,
             outputs=outputs,

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -4,7 +4,12 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- pywps>=4.2
+# restore once an official pywps release contain the fix
+#- pywps>=4.2
 - sphinx
 - nbsphinx
 - ipython
+- pip
+- pip:
+  # delete once an official pywps release contain this fix, also delete in Makefile
+  - https://github.com/Ouranosinc/pywps/archive/2a55b6e95f51c648dc94bf3c89db7370b56c1c9c.zip

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,8 +11,8 @@ search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
 
 [bumpversion:file:docs/source/conf.py]
-search = release = '{current_version}'
-replace = release = '{new_version}'
+search = version|release = {current_version}
+replace = {new_version}
 
 [bumpversion:file:Dockerfile]
 search = Version="{current_version}"


### PR DESCRIPTION
## Overview

This PR applies the cookiecutter PR https://github.com/bird-house/cookiecutter-birdhouse/pull/96 to ensure no silent ReadTheDocs build failure and for Travis-CI to also catch ReadTheDocs build failure before PR is merged.

Successful RtD generation: https://emu.readthedocs.io/en/test-rtd-build/ and matching RtD build logs: https://readthedocs.org/api/v2/build/11555381.txt

Changes:

* Turn RtD warnings to build failure so they do not fail silently.

* Change Travis-CI build config to also build Epub and Latex doc format to catch RtD failure on Travis-CI before PR is merged.

* Various changes to remove all warnings in doc build since warnings will now fail the doc build.

  * For doc build only, to work-around warnings, use a new PYWPS release to support RST anonymous links, currently installing PYWPS from source (with commit hash locked so it is reproducible) since no release yet (PR https://github.com/geopython/pywps/pull/542)

  * Anaconda build badge do not exist anymore so it had to be removed.

Unrelated changes part of this PR (sorry !):

* Other cookiecutter changes that are unapplied previously are also part of this PR.  You might want to look at each commit to avoid the noises.
