### PR TITLE
Refresh cookiecutter and undo pywps source pin

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
     "template": "https://github.com/bird-house/cookiecutter-birdhouse.git",
-    "commit": "7ec7b8b69bbb900d6a300854af0e2a7357b83cdf",
+    "commit": "f157ea8419fd4e32a9e4d52e613c90c807190e7e",
     "skip": [
         "emu/processes/wps_say_hello.py",
         "tests/test_wps_hello.py",

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ install:
 develop:
 	@echo "Installing development requirements for tests and docs ..."
 	@-bash -c 'pip install -e ".[dev]"'
-	@-bash -c 'pip install git+https://github.com/Ouranosinc/pywps@2a55b6e95f51c648dc94bf3c89db7370b56c1c9c#egg=pywps --upgrade'
 
 .PHONY: start
 start:

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -4,12 +4,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-# restore once an official pywps release contain the fix
-#- pywps>=4.2
+- pywps>=4.2.7
 - sphinx
 - nbsphinx
 - ipython
-- pip
-- pip:
-  # delete once an official pywps release contain this fix, also delete in Makefile
-  - https://github.com/Ouranosinc/pywps/archive/2a55b6e95f51c648dc94bf3c89db7370b56c1c9c.zip

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,10 +1,10 @@
-pytest
+pytest>=6.0
 flake8
 pytest-flake8
 ipython
 pytest-notebook
 nbsphinx
-nbval
+nbval>=0.9.6
 nbconvert
 sphinx>=1.7
 bumpversion


### PR DESCRIPTION
This PR undo the pywps source pinning needed to build documentation in the previous PR https://github.com/bird-house/emu/pull/105 and https://github.com/bird-house/cookiecutter-birdhouse/pull/96.

RtD test build https://emu.readthedocs.io/en/test-rtd-build/ and matching build logs https://readthedocs.org/api/v2/build/11602916.txt (commit 3190e5b9a57329487d058e5dcf43cd367e0dcd3f).

