### PR TITLE
update to pywps >4.5.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - name: Checkout repository and submodules
       uses: actions/checkout@v2
@@ -31,15 +31,15 @@ jobs:
       run: make test
     - name: Lint with flake8 ⚙️
       run: make lint
-      if: matrix.python-version == 3.6
+      if: matrix.python-version == 3.7
     # - name: Check formatting with black ⚙️
-    #   run: black --check --target-version py36 birdy tests
-    #   if: matrix.python-version == 3.6
+    #   run: black --check --target-version py37 birdy tests
+    #   if: matrix.python-version == 3.7
     - name: Build docs 🏗️
       run: make docs
-      if: matrix.python-version == 3.6
+      if: matrix.python-version == 3.7
     # - name: Run smoke tests ⚙️
     #   run: |
     #     export PYWPS_CFG=$PWD/etc/smoke-pywps.cfg
     #     make smoke
-    #   if: matrix.python-version == 3.6
+    #   if: matrix.python-version == 3.7

--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,8 @@ channels:
 - defaults
 dependencies:
 - pip
-- python>=3.6
-- pywps>=4.4.5,<4.5
+- python>=3.7,<3.10
+- pywps>=4.5.1,<4.6
 - jinja2
 - click
 - psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pywps>=4.4.5
+pywps>=4.5.1
 jinja2
 click
 psutil

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
 CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
-REQUIRES_PYTHON = ">=3.6.0"
+REQUIRES_PYTHON = ">=3.7.0"
 
 about = {}
 with open(os.path.join(here, 'emu', '__version__.py'), 'r') as f:

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ classifiers = [
     'Programming Language :: Python',
     'Natural Language :: English',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
## Overview

This PR updates the requirements to use pywps 4.5.x. Skipped support for Python 3.6. Python 3.10 not working yet.

## Related Issue / Discussion

## Additional Information


