### PR TITLE
Add Docker Publishing workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,45 @@
+name: Docker Hub Publishing
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: read
+
+env:
+  LATEST_TAG: birdhouse/emu:latest
+  RELEASE_TAG: birdhouse/emu:${{ github.ref_name }}
+
+jobs:
+  build:
+    name: Build and publish image on Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build Docker image and publish to Docker Hub
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: true
+          tags: ${{ env.LATEST_TAG }},${{ env.RELEASE_TAG }}

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -14,9 +14,12 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  TEST_TAG: birdhouse/emu:test
+
 jobs:
   build:
-    name: Build and Test Docker image
+    name: Build Docker image
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -36,17 +39,17 @@ jobs:
       - name: Build Docker image (no push)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
-          file: "Dockerfile"
-          tags: birdhouse/emu:test
-          load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          context: .
+          file: "Dockerfile"
+          load: true
           push: false
+          tags: ${{ env.TEST_TAG }}
 
       - name: Run Docker image
         run: |
-          docker run --rm -p 9099:9099 birdhouse/emu:test sh -c '
+          docker run --rm ${{ env.TEST_TAG }} sh -c '
             emu start -d
             sleep 2s
             emu status

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Changes
     * `tox.toml` is now available for local testing purposes.
 * Added a workflow for automatically accepting non-breaking changes originating from `Dependabot`.
 * Moved all CI dependencies into `.github` to help de-clutter the top-level.
+* Added a Docker Hub publishing workflow.
 
 .. _changes_0.13.0:
 


### PR DESCRIPTION
## Overview

Changes:

* Added a Docker Hub publishing workflow
* Slightly adjusted the Docker testing workflow

## Related Issue / Discussion

This workflow has been tested in a few other projects. Access tokens and usernames must be added and maintained within the project settings.
